### PR TITLE
load-info arg should be set true when executed from file_taint

### DIFF
--- a/scripts/bug_mining.py
+++ b/scripts/bug_mining.py
@@ -148,6 +148,7 @@ pandalog = "%s/%s/queries-%s.plog" % (project['directory'], project['name'], os.
 print("pandalog = [%s] " % pandalog)
 
 panda_args = {
+    'syscalls2': { 'load-info': True },
     'pri': {},
     'pri_dwarf': {
         'proc': proc_name,


### PR DESCRIPTION
file_taint plugin must be used with the state 'syscalls2:load-info=True', because it calls .enter_switch without the "__syscall_meta" not to be loaded. 
As a result, at [this line](https://github.com/panda-re/panda/blob/master/panda/plugins/syscalls2/gen_syscall_switch_enter_linux_x86.cpp#L23) lava crashed due to NULL pointer dereference (syscall_meta == null).
I don't know why is a default value of load-info False, but I've fixed a lava script which can load syscalls2 correctly.
