### PR TITLE
Update installation scripts

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,9 @@
 FROM i386/debian:stretch
+# i386/debian includes commented lines in /etc/apt/sources.list, which point to 
+# snapshots of last available versions of packages for wheezy, along with the broken
+# repo links. This line swaps the commented and uncommented lines in /etc/apt/sources.list.
+RUN awk '{ if ($0 ~ /^#/) print substr($0, 3); else print "# " $0 }' /etc/apt/sources.list > /tmp/sources && cat /tmp/sources > /etc/apt/sources.list && \
+    echo 'Acquire::Check-Valid-Until "false";' >> /etc/apt/apt.conf.d/10no--check-valid-until
 RUN echo deb http://archive.debian.org/debian wheezy-backports main >> /etc/apt/sources.list
 RUN apt-get update
 RUN apt-get install -y sudo build-essential python wget cmake gdb gawk mlocate \

--- a/docker/sources.list
+++ b/docker/sources.list
@@ -4,16 +4,32 @@
 
 #deb cdrom:[Debian GNU/Linux 7.8.0 _Wheezy_ - Official i386 NETINST Binary-1 20150110-13:31]/ wheezy main
 
-deb http://ftp.us.debian.org/debian/ wheezy main
-deb-src http://ftp.us.debian.org/debian/ wheezy main
+# The below repositories are now archived and unavailable
+#deb http://ftp.us.debian.org/debian/ wheezy main
+#deb-src http://ftp.us.debian.org/debian/ wheezy main
+#
+#deb http://security.debian.org/ wheezy/updates main
+## Line commented out by installer because it failed to verify:
+##deb-src http://security.debian.org/ wheezy/updates main
+#
+## wheezy-updates, previously known as 'volatile'
+#deb http://ftp.us.debian.org/debian/ wheezy-updates main
+#deb-src http://ftp.us.debian.org/debian/ wheezy-updates main
+#
+#deb http://ftp.us.debian.org/debian/ wheezy-backports main
+#deb-src http://ftp.us.debian.org/debian/ wheezy-backports main
 
-deb http://security.debian.org/ wheezy/updates main
+# Updated snapshot repositories (of all repos above)
+deb http://snapshot.debian.org/archive/debian/20211106T025313Z/ wheezy main
+deb-src http://snapshot.debian.org/archive/debian/20211106T025313Z/ wheezy main
+
+deb http://snapshot.debian.org/archive/debian-security/20211106T025313Z/ wheezy/updates main
 # Line commented out by installer because it failed to verify:
-#deb-src http://security.debian.org/ wheezy/updates main
+#deb-src http://snapshot.debian.org/archive/debian-security/20211106T025313Z/ wheezy/updates main
 
 # wheezy-updates, previously known as 'volatile'
-deb http://ftp.us.debian.org/debian/ wheezy-updates main
-deb-src http://ftp.us.debian.org/debian/ wheezy-updates main
+deb http://snapshot.debian.org/archive/debian/20211106T025313Z/ wheezy-updates main
+deb-src http://snapshot.debian.org/archive/debian/20211106T025313Z/ wheezy-updates main
 
-deb http://ftp.us.debian.org/debian/ wheezy-backports main
-deb-src http://ftp.us.debian.org/debian/ wheezy-backports main
+deb http://snapshot.debian.org/archive/debian/20211106T025313Z/ wheezy-backports main
+deb-src http://snapshot.debian.org/archive/debian/20211106T025313Z/ wheezy-backports main

--- a/init-host.py
+++ b/init-host.py
@@ -88,14 +88,14 @@ def main():
     if not isfile(join(TAR_DIR, basename(TAR_URL))):
         progress("Downloading %s".format(basename(TAR_URL)))
         os.chdir(TAR_DIR)
-        run(["wget", TAR_URL, "-O", QCOW_FILE_NAME])
+        run(["wget", TAR_URL])
         os.chdir(LAVA_DIR)
     else:
         progress("Found existing target_bins/{}".format(basename(TAR_URL)))
 
     if not isfile(join(LAVA_DIR, basename(QCOW_URL))):
         progress("Downloading {}".format(basename(QCOW_URL)))
-        run(["wget", QCOW_URL])
+        run(["wget", QCOW_URL, "-O", QCOW_FILE_NAME])
     else:
         progress("Found existing {}".format(basename(QCOW_URL)))
 

--- a/init-host.py
+++ b/init-host.py
@@ -18,7 +18,10 @@ from os.path import expandvars
 from colorama import Fore
 from colorama import Style
 
-QCOW_URL = "http://panda.moyix.net/~moyix/wheezy_panda2.qcow2"
+# moyix server is down, so we use the official panda image
+# QCOW_URL = "http://panda.moyix.net/~moyix/wheezy_panda2.qcow2"
+QCOW_URL = "https://panda.re/qcows/linux/debian/7.3/x86/debian_7.3_x86.qcow"
+QCOW_FILE_NAME = "wheezy_panda2.qcow2"
 TAR_URL = "ftp://ftp.astron.com/pub/file/file-5.22.tar.gz"
 LAVA_DIR = dirname(abspath(sys.argv[0]))
 os.chdir(LAVA_DIR)
@@ -85,7 +88,7 @@ def main():
     if not isfile(join(TAR_DIR, basename(TAR_URL))):
         progress("Downloading %s".format(basename(TAR_URL)))
         os.chdir(TAR_DIR)
-        run(["wget", TAR_URL])
+        run(["wget", TAR_URL, "-O", QCOW_FILE_NAME])
         os.chdir(LAVA_DIR)
     else:
         progress("Found existing target_bins/{}".format(basename(TAR_URL)))

--- a/setup.py
+++ b/setup.py
@@ -282,6 +282,10 @@ def main():
         except OSError:
             print "Warning: Panda build directory is already there"
         os.chdir(PANDA_DIR)
+        # The dtc submodule no longer works through git://, so we replace it with https://.
+        run(['sed', '-i', 's|url = git://git.qemu-project.org/dtc.git|url = https://git.qemu-project.org/dtc.git|g', '.gitmodules'])
+        # sync the submodule (apply the url protocol change)
+        run(['git', 'submodule', 'sync'])
         run(['git', 'submodule', 'update', '--init', 'dtc'])
         os.chdir(PANDA_BUILD_DIR)
         run([join(PANDA_DIR, 'build.sh')])


### PR DESCRIPTION
### Changes Summary
- Update Docker image to use snapshot repos (current are broken) and disable expiration checks (in `Dockerfile`)
- Update `docker/sources.list` to use snapshot repos (current are broken)
- Update `QCOW_URL` to point to an official panda qcow download while `panda.moyix.net` server is offline.
- Update Panda DTC submodule to use `https://` instead of `git://` (`git://` is broken)