### PR TITLE
Update QCOW_URL to HTTPS as HTTP link is non-functional

### DIFF
--- a/init-host.py
+++ b/init-host.py
@@ -18,7 +18,7 @@ from os.path import expandvars
 from colorama import Fore
 from colorama import Style
 
-QCOW_URL = "http://panda.moyix.net/~moyix/wheezy_panda2.qcow2"
+QCOW_URL = "https://panda.moyix.net/~moyix/wheezy_panda2.qcow2"
 # if moyix server is down, this image will also work
 # QCOW_URL = "https://panda.re/qcows/linux/debian/7.3/x86/debian_7.3_x86.qcow"
 QCOW_FILE_NAME = "wheezy_panda2.qcow2"


### PR DESCRIPTION
This update modifies the `QCOW_URL` to use a secure HTTPS link instead of HTTP, as the HTTP link is no longer functional. This ensures the correct retrieval of the `wheezy_panda2.qcow2` file.