### PR TITLE
Utilize Protobuf for enforcing Schema Synchronization

### DIFF
--- a/.github/workflows/parallel_tests.yml
+++ b/.github/workflows/parallel_tests.yml
@@ -58,7 +58,16 @@ jobs:
         run: |
           cd python
           python3 -m pip install --upgrade build
+          python3 -m pip install pytest protobuf>=4.21.0
           python3 -m build --wheel .
+          python3 -m pip install dist/*.whl
+
+      - name: Quick Python Test
+        run: |
+          cd python
+          pytest
+        env:
+          PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION : 'python'
 
   test_install_script:
     if: github.repository == 'panda-re/lava'
@@ -103,7 +112,7 @@ jobs:
       run: |
         echo "localhost:5432:*:${POSTGRES_USER}:${POSTGRES_PASSWORD}" > ~/.pgpass
         chmod 600 ~/.pgpass
-        lava -ak toy
+        python -m pyroclastic.lava -ak toy
       env:
         USER: ${{ github.actor }}
         POSTGRES_USER: postgres

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Saving copy of SQL for wheel file
-*.sql
-
 # ignore IDE and any panda wheel/debian packages
 .vscode
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,18 @@
+# Don't save protobuf files
+*.pb.h
+*.pb.cc
+*_pb2.py
+
+# Don't saved generated SQL file used in wheel'
+*.sql
+
 # ignore IDE and any panda wheel/debian packages
 .vscode
 .idea
 *.deb
 *.whl
 .env
+-.s
 
 # this existed before
 .gdb_history

--- a/README.md
+++ b/README.md
@@ -34,22 +34,35 @@ $ DOCKER_BUILDKIT=1 docker build lava .
 ```
 
 ## Ubuntu, Debian
-On a system running Ubuntu 22.04, you should be able to just run `bash install.sh`. Note that this [install script](./install.sh) will install packages and make changes to your system.
+### Local Installation
+On a system running Ubuntu 22.04, you should be able to just run `bash install.sh`. 
+Note that this [install script](https://github.com/panda-re/lava/blob/master/install.sh) will install packages and make changes to your system. 
+You can remove the binaries using `sudo apt-get remove lava`.
+
+Once you finish installing the binary, then you can install locally running `pip install python/`. 
+
+**NOTE** that the Python package requires a SQL file generated from compiling the binaries that is placed into `python/src/pyroclastic/data/lava.sql`. 
+Without this file, the Python package will not work correctly.
+
+### Regular installation
+Alternatively, you can manually install LAVA's dependencies and then build from source. 
+Download the Debian packages located in the [releases](https://github.com/panda-re/lava/releases). Then install the python package `pip install pyroclastic`.
 
 ## Final steps
 
 ### Utilizing host.json
-Next, run `init-host.py` to generate a `host.json`.
+Next, run `init_host` to generate a `host.json` in your `~/.lava` directory.
 This file is used by LAVA to store settings specific
 to your machine. You can edit these settings as necessary, but the default
-values should work, see [vars.sh](scripts/vars.sh).
+values should work, see [vars.py](https://github.com/panda-re/lava/blob/master/python/src/pyroclastic/utils/vars.py).
 
 A few values to keep in mind are the following:
-* **buildhost** This is the location of where LAVA is being executed from. Currently, it defaults to `localhost`
-* **docker** is the name of the docker image to use that has the LAVA binaries. Currently it defaults to `lava32`, but you can switch this to `pandare/lava`
 * **pguser** This is the name of database user, currently defaults to `postgres`
-* **pgpass** This is the password of the database user, currently defaults to `postgrespostgres`
-* **host** is the name of the Postgres SQL database with all the LAVA bugs. Currently it defaults to `database`, although if you installed LAVA locally, you likely should change this to `localhost`
+* **host** is the name of the Postgres SQL database with all the LAVA bugs. Currently, it defaults to `database`, although if you installed LAVA locally, you likely should change this to `localhost`
+
+**NOTE**: You also need two environment variables for the Postgres SQL database:
+* `POSTGRES_PASS` This is the password for the Postgres SQL user`
+* `POSTGRES_USER` This is the hostname for the Postgres SQL database
 
 ### Project configurations
 Project configurations are located in the `target_configs` directory, where
@@ -58,47 +71,26 @@ Paths specified within these configuration files are relative to values set
 in your `host.json` file.
 
 ### Setting up postgres SQL database
-As alluded to, you should create a Postgres SQL user. You can use a script to [use default credentials](setup_postgres.sh) for the following:
-* Create the user with default password
+As alluded to, you should create a Postgres SQL user. You can use a script to [using the environment variables](https://github.com/panda-re/lava/blob/master/scripts/setup_postgres.sh) for the following:
+* Create the user with provided username and password from environment variables.
 * Update Postgres SQL database on host to accept traffic from external sources (e. g. LAVA Docker container)
-* Switch password encryption to md5 (Do we need this?)
 
 # Usage
 
-Finally, you can run `./scripts/lava.sh` to actually inject bugs into a program. Just provide the name of a project that is in the `target_configs` directory, for example:
+Finally, you can run `lava` to actually inject bugs into a program. 
+Just provide the name of a project that is in the `target_configs` directory, for example:
 
 ```
-./scripts/lava.sh toy
+lava -ak toy
 ```
 
 You should now have a buggy copy of toy!
 
 If you want to inject bugs into a new target, you will likely need to make some
-modifications. Check out [How-to-Lava](docs/how-to-lava.md) for guidance.
+modifications. Check out [How-to-Lava](https://github.com/panda-re/lava/blob/master/docs/how-to-lava.md) for guidance.
 
 # Documentation
-Check out the [docs](docs/) folder to get started.
-
-
-# Current Status
-## Version 2.0.0
-
-Expected results from test suite:
-```
-Project       RESET    CLEAN    ADD      MAKE     TAINT    INJECT   COMP
-blecho        PASS     PASS     PASS     PASS     PASS     PASS     PASS
-libyaml       PASS     PASS     PASS     PASS     PASS     PASS     PASS
-file          PASS     PASS     PASS     PASS     PASS     PASS     PASS
-toy           PASS     PASS     PASS     PASS     PASS     PASS     PASS
-pcre2         PASS     PASS     PASS     PASS     PASS     PASS     PASS
-jq            PASS     PASS     PASS     PASS     PASS     PASS     PASS
-grep          PASS     PASS     PASS     PASS     PASS     FAIL
-libjpeg       PASS     PASS     PASS     PASS     FAIL
-tinyexpr      PASS     PASS     PASS     PASS     FAIL
-duktape       PASS     PASS     PASS     FAIL
-tweetNaCl     PASS     PASS     FAIL
-gzip          FAIL
-```
+Check out the [docs](https://github.com/panda-re/lava/blob/master/docs/) folder to get started.
 
 # Authors
 

--- a/dependencies/ubuntu_22.04_base.txt
+++ b/dependencies/ubuntu_22.04_base.txt
@@ -24,5 +24,6 @@ libjsoncpp-dev
 g++-10
 
 # FBI needs this, but I think we can remove once Python swap is in
+protobuf-compiler
 libprotobuf-dev
 libprotobuf-c-dev

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,6 +5,16 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 include-package-data = true
 
+[tool.pytest.ini_options]
+# Add both 'src' (for your code) and 'tests' (for generated lava_pb2)
+pythonpath = [
+  "src",
+  "tests",
+]
+
+# Optional: Add this to see your debug prints automatically without typing -s
+addopts = "-s"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["pyroclastic", "pyroclastic.*"]
@@ -32,7 +42,7 @@ dependencies = [
     "numpy",
     "pandare==1.8.78",
     "PyYAML",
-    "SQLAlchemy",
+    "sqlalchemy",
     "tabulate",
     "psycopg2-binary",
     "ijson"

--- a/python/src/pyroclastic/lava.py
+++ b/python/src/pyroclastic/lava.py
@@ -197,10 +197,10 @@ def reset_database(lava_paths: Paths, config: dict):
 
 def make(lava_paths: Paths, config: dict):
     """
-    This compiles the target program with LAVA's LLVM passes to enable bug triggering.
+    This compiles the target program with LAVA taint queries added.
     This requires static compiling as the generic PANDA QCows might not have all libraries for dynamic linking.
     The binary will be in ./target_injections/<project>/<tar-directory>/
-    Then, during the "make install" step, it will be placed in the
+    Then, during the "make install" step, the binary should be in
     ./target_injections/<project>/<tar-directory>/lava-install/bin/ folder
     Eventually, in the taint step, we will copy the input folders to go with the binary for dynamic analysis.
     """
@@ -270,6 +270,7 @@ def main():
             progress("everything", 1, "No fixups")
         time_diff = tock(start)
         progress("everything", 1, f"add queries complete {time_diff} seconds")
+
     if args.make:
         make(path_manager, config)
 

--- a/python/src/pyroclastic/taint/bug_mining.py
+++ b/python/src/pyroclastic/taint/bug_mining.py
@@ -28,8 +28,7 @@ def run_taint_pipeline(lava_project: str):
     project = parse_vars(lava_project)
 
     # Initialize PANDA
-    qemu_path = project['qemu']
-    panda = Panda(generic=qemu_path.split('-')[-1])
+    panda = Panda(generic=project['qemu'])
 
     class State:
         command_args = []

--- a/python/src/pyroclastic/utils/funcs.py
+++ b/python/src/pyroclastic/utils/funcs.py
@@ -41,7 +41,7 @@ def get_inject_parser():
     return parser
 
 
-def print_tail(logfile, n=8):
+def print_tail(logfile, n=9):
     if os.path.exists(logfile):
         with open(logfile, "r") as f:
             for line in deque(f, n):

--- a/python/src/pyroclastic/utils/init_host.py
+++ b/python/src/pyroclastic/utils/init_host.py
@@ -26,7 +26,7 @@ def main():
                         help='If set, have host.json assume LAVA will be run from Docker environment')
     parser.add_argument('--container', '-c', dest='container', default='lava64',
                         help='Set the name of the Docker container with LAVA installed. (default: lava64)')
-    parser.add_argument('--qemu', '-q', dest='qemu', default='panda-system-x86_64',
+    parser.add_argument('--qemu', '-q', dest='qemu', default='x86_64',
                         choices=get_valid_architectures(),
                         help='Set the name of the Docker container with LAVA installed. (default: lava64)')
     parser.add_argument('--action', '-a', dest='action', action='store_true',

--- a/python/src/pyroclastic/utils/vars.py
+++ b/python/src/pyroclastic/utils/vars.py
@@ -73,7 +73,7 @@ def validate_project(project_dict: dict):
     assert 'db' in project_dict
 
 
-def get_project_env(llvm_dir: str, arch: str = "x86_64", mode:str = "default"):
+def get_project_env(llvm_dir: str, arch: str = "x86_64", mode: str = "default"):
     """
     Generates environment variables based on target architecture.
     mode: 'default', 'full', or 'panda'
@@ -137,6 +137,7 @@ def parse_vars(project_name: str):
         print("Your project config file is missing a required field:\n{}".format(e))
         raise
 
+    project_data["host_path"] = host_json_path
     for field, prefix in [("tarfile", "tar_dir")]:
         project_data[field] = host[prefix] + os.path.sep + project_data[field]
 

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -1,34 +1,66 @@
+import unittest
+import inspect
 import lava_pb2
+from pyroclastic.utils import database_types
 from pyroclastic.utils.database_types import Base
-import sys
 
 
-def verify_all_tables():
-    mismatches = []
-    # Loop through every SQLAlchemy table you've defined
-    for table_name, mapper in Base.registry.mappers.items():
-        class_name = mapper.class_.__name__
+class TestSchema(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Build the maps once for all test methods in this class."""
+        # This will reveal if your new tables are registered correctly
+        cls.sql_mappers = {m.class_.__name__: m for m in Base.registry.mappers}
+        cls.all_classes = dict(inspect.getmembers(database_types, inspect.isclass))
 
-        # Look for the matching message in the Protobuf file
-        proto_msg = getattr(lava_pb2, class_name, None)
-        if not proto_msg:
-            # Maybe some tables are internal to Python, but usually they should match
-            print(f"Warning: No Protobuf definition for table {class_name}")
-            continue
+        print("\n" + "=" * 50)
+        print("DEBUG: LAVA SCHEMA AUDITOR (unittest)")
+        print(f"Total Mappers: {len(cls.sql_mappers)}")
+        print(f"Mappers: {list(cls.sql_mappers.keys())}")
+        print("=" * 50)
 
-        sql_columns = set(mapper.columns.keys())
-        proto_fields = set(proto_msg.DESCRIPTOR.fields_by_name.keys())
+    def get_python_fields(self, cls_name):
+        """
+        Helper to extract field names from either a Mapper or a Composite/Dataclass
+        """
+        if cls_name in self.sql_mappers:
+            mapper = self.sql_mappers[cls_name]
+            # Columns + Relationships + Association Proxies
+            return (set(mapper.all_orm_descriptors.keys()) |
+                    set(mapper.columns.keys()) |
+                    set(mapper.synonyms.keys()))
+        elif cls_name in self.all_classes:
+            target_cls = self.all_classes[cls_name]
+            return set(getattr(target_cls, '__annotations__', {}).keys()) | set(target_cls.__dict__.keys())
+        return set()
 
-        # Check for drift
-        missing_in_sql = proto_fields - sql_columns
-        if missing_in_sql:
-            mismatches.append(f"Table '{class_name}' is missing columns defined in .proto: {missing_in_sql}")
+    def test_protobuf_coverage(self):
+        """Ensure every Proto message has a corresponding Python class or table."""
+        proto_messages = set(lava_pb2.DESCRIPTOR.message_types_by_name.keys())
+        python_types = set(self.sql_mappers.keys()) | set(self.all_classes.keys())
 
-    if mismatches:
-        for m in mismatches: print(f"ERROR: {m}")
-        sys.exit(1)  # Fail the CI build
-    print("Schema synchronized perfectly.")
+        missing = proto_messages - python_types
+        self.assertEqual(len(missing), 0, f"Protobuf defines messages missing in Python: {missing}")
+
+    def test_field_synchronization(self):
+        """Ensure every field in every Proto message exists in Python."""
+        mismatches = []
+
+        for msg_name, msg_descriptor in lava_pb2.DESCRIPTOR.message_types_by_name.items():
+            # If the class itself is missing, test_protobuf_coverage will catch it.
+            # We skip field checks for missing classes to avoid redundant errors.
+            if msg_name not in self.sql_mappers and msg_name not in self.all_classes:
+                continue
+
+            proto_fields = set(msg_descriptor.fields_by_name.keys())
+            py_fields = self.get_python_fields(msg_name)
+
+            missing_in_python = proto_fields - py_fields
+            if missing_in_python:
+                mismatches.append(f"Type '{msg_name}' missing fields: {missing_in_python}")
+
+        self.assertEqual(len(mismatches), 0, "\n" + "\n".join(mismatches))
 
 
 if __name__ == "__main__":
-    verify_all_tables()
+    unittest.main()

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -1,0 +1,34 @@
+import lava_pb2
+from pyroclastic.utils.database_types import Base
+import sys
+
+
+def verify_all_tables():
+    mismatches = []
+    # Loop through every SQLAlchemy table you've defined
+    for table_name, mapper in Base.registry.mappers.items():
+        class_name = mapper.class_.__name__
+
+        # Look for the matching message in the Protobuf file
+        proto_msg = getattr(lava_pb2, class_name, None)
+        if not proto_msg:
+            # Maybe some tables are internal to Python, but usually they should match
+            print(f"Warning: No Protobuf definition for table {class_name}")
+            continue
+
+        sql_columns = set(mapper.columns.keys())
+        proto_fields = set(proto_msg.DESCRIPTOR.fields_by_name.keys())
+
+        # Check for drift
+        missing_in_sql = proto_fields - sql_columns
+        if missing_in_sql:
+            mismatches.append(f"Table '{class_name}' is missing columns defined in .proto: {missing_in_sql}")
+
+    if mismatches:
+        for m in mismatches: print(f"ERROR: {m}")
+        sys.exit(1)  # Fail the CI build
+    print("Schema synchronized perfectly.")
+
+
+if __name__ == "__main__":
+    verify_all_tables()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -34,7 +34,11 @@ endif()
 # Set the project version dynamically
 project(LAVA VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH})
 include(GNUInstallDirs)
-set(CMAKE_VERBOSE_MAKEFILE OFF)
+if (DEFINED DEBUG)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+else()
+    set(CMAKE_VERBOSE_MAKEFILE OFF)
+endif()
 
 # Print the project version for debugging
 message(STATUS "LAVA Project version: ${PROJECT_VERSION}")

--- a/tools/CPackConfig.txt
+++ b/tools/CPackConfig.txt
@@ -9,7 +9,7 @@ if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
 	set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "arm64")
 endif()
 
-set(CPACK_STRIP_FILES false)
+set(CPACK_STRIP_FILES true)
 
 # Compression settings
 set(CPACK_DEBIAN_PACKAGE_COMPRESSION_TYPE "xz") # Use xz compression for smaller package size

--- a/tools/fbi/src/find_bug_inj.cpp
+++ b/tools/fbi/src/find_bug_inj.cpp
@@ -551,7 +551,7 @@ void taint_query_pri(Json::Value& ple) {
         // NB: we don't know liveness info yet. defer byte selection until later.
         assert(si.isMember("astLocId"));
         unsigned long ast_loc_id = std::strtoul(si["astLocId"].asString().c_str(), 0, 0);
-        LavaASTLoc ast_loc(ind2str[ast_loc_id]);
+        ASTLoc ast_loc(ind2str[ast_loc_id]);
         assert(ast_loc.filename.size() > 0);
 
         const SourceLval *lval = create(SourceLval{0, ast_loc, si["astnodename"].asString(), len});
@@ -885,7 +885,7 @@ void attack_point_lval_usage(Json::Value ple) {
 
     dprintf("%lu viable duas remain\n", recent_dead_duas.size());
     assert(si.isMember("astLocId"));
-    LavaASTLoc ast_loc(ind2str[ast_id]);
+    ASTLoc ast_loc(ind2str[ast_id]);
     assert(ast_loc.filename.size() > 0);
     transaction t(db->begin());
     const AttackPoint *atp;

--- a/tools/include/pirate_mark_lava.h
+++ b/tools/include/pirate_mark_lava.h
@@ -4,23 +4,6 @@
 // For LAVA use only
 #define LAVA_MAGIC 0xabcd
 
-// Define architecture-specific register names, WIP
-#if defined(CONFIG_X86_64) || defined(__x86_64__)
-    #define REG0 rax
-    #define REG1 rdi
-#elif defined(CONFIG_I386) || (defined(__i386__) && !defined(__x86_64__))
-    #define REG0 eax
-    #define REG1 ebx
-#elif defined(CONFIG_ARM) || defined(__arm__)
-    #define REG0 r0
-    #define REG1 r1
-#elif defined(CONFIG_ARM64) || defined(__aarch64__)
-    #define REG0 x0
-    #define REG1 x1
-#else
-    #error "Unsupported architecture"
-#endif
-
 // Taken from here
 // https://github.com/panda-re/libhc/blob/main/hypercall.h
 #include "hypercall.h"
@@ -43,14 +26,14 @@ void vm_lava_attack_point(lavaint ast_loc_id, unsigned long linenum, lavaint inf
   phs.src_filename = ast_loc_id;
   phs.src_linenum = linenum;
   phs.info = info;
-  phs.insertion_point = 0;  // this signals that there isnt an insertion point
+  phs.insertion_point = 0;  // this signals that there isn't an insertion point
   igloo_hypercall(LAVA_MAGIC, (unsigned long) &phs);
 }
 
-// Right now, this only can work for x86-64, but the principle carries for other architectures
 // see /tools/lavaTool/include/PriQueryPointHandler.h
 // NOTE: You can NOT use the hypercall directly, it will not work because then srcInfo on 
 // TaintQueryPri will point to the hypercall function NOT the source code!
+#if defined(CONFIG_X86_64) || defined(__x86_64__)
 #define vm_lava_pri_query_point(ast_loc_id, line_num, extra_info) do { \
     volatile PandaHypercallStruct phs = {0}; \
     phs.magic = LAVA_MAGIC; \
@@ -63,5 +46,44 @@ void vm_lava_attack_point(lavaint ast_loc_id, unsigned long linenum, lavaint inf
     DECLARE_REGISTER(1, rdi, (unsigned long) &phs) \
     ASM() \
 } while (0)
-
+#elif defined(CONFIG_I386) || (defined(__i386__) && !defined(__x86_64__))
+#define vm_lava_pri_query_point(ast_loc_id, line_num, extra_info) do { \
+    volatile PandaHypercallStruct phs = {0}; \
+    phs.magic = LAVA_MAGIC; \
+    phs.action = LAVA_PRI_QUERY_POINT; \
+    phs.src_filename = ast_loc_id; \
+    phs.src_linenum = line_num; \
+    phs.insertion_point = 1; \
+    phs.info = extra_info; \
+    DECLARE_REGISTER(0, eax, LAVA_MAGIC) \
+    DECLARE_REGISTER(1, ebx, (unsigned long) &phs) \
+    ASM() \
+} while (0)
+#elif defined(CONFIG_ARM) || defined(__arm__)
+#define vm_lava_pri_query_point(ast_loc_id, line_num, extra_info) do { \
+    volatile PandaHypercallStruct phs = {0}; \
+    phs.magic = LAVA_MAGIC; \
+    phs.action = LAVA_PRI_QUERY_POINT; \
+    phs.src_filename = ast_loc_id; \
+    phs.src_linenum = line_num; \
+    phs.insertion_point = 1; \
+    phs.info = extra_info; \
+    DECLARE_REGISTER(0, r0, LAVA_MAGIC) \
+    DECLARE_REGISTER(1, r1, (unsigned long) &phs) \
+    ASM() \
+} while (0)
+#elif defined(CONFIG_ARM64) || defined(__aarch64__)
+#define vm_lava_pri_query_point(ast_loc_id, line_num, extra_info) do { \
+    volatile PandaHypercallStruct phs = {0}; \
+    phs.magic = LAVA_MAGIC; \
+    phs.action = LAVA_PRI_QUERY_POINT; \
+    phs.src_filename = ast_loc_id; \
+    phs.src_linenum = line_num; \
+    phs.insertion_point = 1; \
+    phs.info = extra_info; \
+    DECLARE_REGISTER(0, x0, LAVA_MAGIC) \
+    DECLARE_REGISTER(1, x1, (unsigned long) &phs) \
+    ASM() \
+} while (0)
+#endif
 #endif

--- a/tools/lavaODB/src/CMakeLists.txt
+++ b/tools/lavaODB/src/CMakeLists.txt
@@ -1,47 +1,65 @@
-include(GNUInstallDirs)
-set (GENERATED ${CMAKE_CURRENT_SOURCE_DIR}/../generated)
-set (PYTHON_DATA ${CMAKE_CURRENT_SOURCE_DIR}/../../../python/src/pyroclastic/data)
+set(GENERATED ${CMAKE_CURRENT_SOURCE_DIR}/../generated)
+set(PYTHON_DATA ${CMAKE_CURRENT_SOURCE_DIR}/../../../python/src/pyroclastic/data)
+set(PYTHON_TEST ${CMAKE_CURRENT_SOURCE_DIR}/../../../python/tests)
 
-if (NOT EXISTS ${GENERATED})
-    file(MAKE_DIRECTORY ${GENERATED})
-endif()
+# Ensure folders exist
+file(MAKE_DIRECTORY ${GENERATED})
 
-set(cxxFile "${GENERATED}/lava-odb.cxx")
-set(hxxFile "${GENERATED}/lava-odb.hxx")
-set(ixxFile "${GENERATED}/lava-odb.ixx")
-set(sqlFile "${GENERATED}/lava.sql")
+# --- STEP 1: PROTOBUF GENERATION ---
+set(PROTO_HXX "${GENERATED}/lava.pb.h")
+set(PROTO_CXX "${GENERATED}/lava.pb.cc")
+set(PROTO_PY  "${PYTHON_TEST}/lava_pb2.py")
 
-set(ODB_GENERATED_FILES ${cxxFile} ${hxxFile} ${ixxFile} ${sqlFile})
+add_custom_command(
+    OUTPUT ${PROTO_HXX} ${PROTO_CXX} ${PROTO_PY}
+    COMMAND protoc -I=${CMAKE_CURRENT_SOURCE_DIR}
+                   --cpp_out=${GENERATED}
+                   --python_out=${PYTHON_TEST}
+                   ${CMAKE_CURRENT_SOURCE_DIR}/lava.proto
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/lava.proto
+    COMMENT "Building Protobuf: lava.proto"
+)
 
-set(ODB_OPTS -d pgsql -o ${GENERATED} --std c++11 --generate-query --generate-schema --generate-prepared --cxx-prologue '\#include \"pgarray.hxx\"' --sql-name-case lower )
-set(ODB_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-set(ODB_HXX ${CMAKE_CURRENT_SOURCE_DIR}/../include/lava.hxx)
+# --- STEP 2: ODB GENERATION ---
+set(ODB_HXX_SRC ${CMAKE_CURRENT_SOURCE_DIR}/../include/lava.hxx)
+set(ODB_GENERATED_FILES
+    "${GENERATED}/lava-odb.cxx"
+    "${GENERATED}/lava-odb.hxx"
+    "${GENERATED}/lava-odb.ixx"
+    "${GENERATED}/lava.sql")
 
-add_custom_command (
+# Note the -I${GENERATED} so ODB can find lava.pb.h
+set(ODB_OPTS -d pgsql -o ${GENERATED} --std c++14
+             -I${GENERATED} -I${CMAKE_CURRENT_SOURCE_DIR}/../include
+             --generate-query --generate-schema --generate-prepared
+             --cxx-prologue '\#include \"pgarray.hxx\"' --sql-name-case lower)
+
+# --- STEP 2.5: TELL CMAKE THESE FILES ARE PRODUCED DURING BUILD ---
+set_source_files_properties(
+    ${PROTO_CXX}
+    ${PROTO_HXX}
+    "${GENERATED}/lava-odb.cxx"
+    "${GENERATED}/lava-odb.hxx"
+    PROPERTIES GENERATED TRUE
+)
+
+add_custom_command(
     OUTPUT ${ODB_GENERATED_FILES}
-    COMMAND odb ${ODB_OPTS} ${ODB_HXX}
-    COMMAND ${CMAKE_COMMAND} -E copy ${sqlFile} ${PYTHON_DATA}/lava.sql
-    DEPENDS cleanup ${ODB_HXX}
-    COMMENT "Generating ODB files and syncing SQL to scripts folder"
+    COMMAND odb ${ODB_OPTS} ${ODB_HXX_SRC}
+    COMMAND ${CMAKE_COMMAND} -E copy "${GENERATED}/lava.sql" ${PYTHON_DATA}/lava.sql
+    DEPENDS ${PROTO_HXX} ${ODB_HXX_SRC}
+    COMMENT "Building ODB mappings from lava.hxx (depends on lava.pb.h)"
 )
 
-add_custom_target (cleanup
-    rm -rf ${GENERATED}/*
-    COMMENT "Cleaning up tools/lavaODB/generated folder"
-)
+# --- STEP 3: THE TARGETS ---
+# Library needs BOTH Protobuf source and ODB source
+add_library(lava-odb_x64 STATIC ${PROTO_CXX} ${GENERATED}/lava-odb.cxx)
 
-# create liblava-odb_x64.a library used by lavaFnTool and lavaTool
-add_library(lava-odb_x64 STATIC ${GENERATED}/lava-odb.cxx)
 set_property(TARGET lava-odb_x64 PROPERTY CXX_STANDARD 17)
-target_link_libraries(lava-odb_x64 odb odb-pgsql)
-add_dependencies(lava-odb_x64 cleanup)
-target_include_directories(lava-odb_x64 BEFORE
-    PUBLIC
-    ${GENERATED}
-    ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_link_libraries(lava-odb_x64 odb odb-pgsql protobuf) # Added protobuf link
 
-install(TARGETS lava-odb_x64
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}  # For shared libraries
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}  # For executables (if applicable)
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}  # For static libraries (if applicable)
+target_include_directories(lava-odb_x64
+    PUBLIC
+    $<BUILD_INTERFACE:${GENERATED}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
 )

--- a/tools/lavaODB/src/lava.proto
+++ b/tools/lavaODB/src/lava.proto
@@ -1,0 +1,117 @@
+syntax = "proto3";
+
+package lava;
+
+message Loc {
+    uint32 line = 2;
+    uint32 column = 3;
+}
+
+message ASTLoc {
+    string filename = 1;
+    Loc begin = 2;
+    Loc end = 3;
+}
+
+message Range {
+    uint32 low = 1;
+    uint32 high = 2;
+}
+
+message SourceLval {
+    uint64 id = 1;
+    ASTLoc loc = 2;
+    string ast_name = 3;
+    uint32 len_bytes = 4;
+}
+
+message LabelSet {
+    uint64 id = 1;
+    uint64 ptr = 2;         // Pointer to labelset during taint run
+    string inputfile = 3;   // Inputfile used for this run.
+    repeated uint32 labels = 4;
+};
+
+message Dua {
+    uint64 id = 1;
+    SourceLval lval = 2;
+    repeated LabelSet viable_bytes = 3;
+    repeated uint32 byte_tcn = 4;
+    repeated uint32 all_labels = 5;
+    string inputfile = 6;
+    uint32 max_tcn = 7;
+    uint32 max_cardinality = 8;
+    uint64 instr = 9;
+    bool fake_dua = 10;
+}
+
+message DuaBytes {
+    uint64 id = 1;
+    Dua dua = 2;
+    Range selected = 3;
+    repeated uint32 all_labels = 4;
+}
+
+message AttackPoint {
+    enum AtpKind {
+        FUNCTION_CALL = 0;
+        POINTER_READ = 1;
+        POINTER_WRITE = 2;
+        QUERY_POINT = 3;
+        PRINTF_LEAK = 4;
+        MALLOC_OFF_BY_ONE = 5;
+    }
+    uint64 id = 1;
+    ASTLoc loc = 2;
+    AtpKind type = 3;
+}
+
+message Bug {
+    enum BugKind {
+        BUG_PTR_ADD = 0;
+        BUG_RET_BUFFER = 1;
+        BUG_REL_WRITE = 2;
+        BUG_PRINTF_LEAK = 3;
+        BUG_MALLOC_OFF_BY_ONE = 4;
+    }
+    uint64 id = 1;
+    BugKind type = 2;
+    DuaBytes trigger = 3;
+    SourceLval trigger_lval = 4;
+    AttackPoint atp = 5;
+    uint64 max_liveness = 6;
+    repeated uint64 extra_duas = 7;
+    uint32 magic = 8;
+}
+
+message Build {
+    uint64 id = 1;
+    repeated Bug bugs = 2;
+    string output = 3;      // path to executable
+    bool compile = 4;       // did the build compile?
+}
+
+message Run {
+    uint64 id = 1;
+    Build build = 2;
+    Bug fuzzed = 3;         // was this run on fuzzed or orig input?
+    int32 exitcode = 4;     // exit code of program
+    string output = 5;      // output of program
+    bool success = 6;       // true unless python script failed somehow.
+    bool validated = 7;     // true if bug successfully triggered by inject.py
+}
+
+message SourceFunction {
+    uint64 id = 1;
+    ASTLoc loc = 2;
+    string name = 3;       // Function name
+}
+
+message Call {
+    uint64 id = 1;
+    uint64 call_instr = 2;    // Instruction count at call
+    uint64 ret_instr = 3;     // Instruction count at ret
+    SourceFunction called_function = 4;
+    string callsite_file = 5;
+    uint32 callsite_line = 6;
+}

--- a/tools/lavaTool/include/LavaMatchHandler.h
+++ b/tools/lavaTool/include/LavaMatchHandler.h
@@ -192,18 +192,18 @@ struct LavaMatchHandler : public MatchFinder::MatchCallback {
         return s.str();
     }
 
-    LavaASTLoc GetASTLoc(const SourceManager &sm, const Stmt *s) {
+    ASTLoc GetASTLoc(const SourceManager &sm, const Stmt *s) {
         assert(!SourceDir.empty());
         FullSourceLoc fullLocStart(sm.getExpansionLoc(s->getBeginLoc()), sm);
         FullSourceLoc fullLocEnd(sm.getExpansionLoc(s->getEndLoc()), sm);
         std::string src_filename = StripPrefix(
                 getAbsolutePath(sm.getFilename(fullLocStart)), SourceDir);
-        return LavaASTLoc(src_filename, fullLocStart, fullLocEnd);
+        return ASTLoc(src_filename, fullLocStart, fullLocEnd);
     }
 
     // A query inserted at a possible attack point. Used, dynamically, just to
     // tell us when an input gets to the attack point.
-    LExpr LavaAtpQuery(LavaASTLoc ast_loc, AttackPoint::Type atpType) {
+    LExpr LavaAtpQuery(ASTLoc ast_loc, AttackPoint::Type atpType) {
         return LBlock({
                 LFunc("vm_lava_attack_point",
                     { LDecimal(GetStringID(StringIDs, ast_loc)), LDecimal(0),
@@ -218,7 +218,7 @@ struct LavaMatchHandler : public MatchFinder::MatchCallback {
     */
     void AttackExpression(const SourceManager &sm, const Expr *toAttack,
             const Expr *parent, const Expr *rhs, AttackPoint::Type atpType) {
-        LavaASTLoc ast_loc = GetASTLoc(sm, toAttack);
+        ASTLoc ast_loc = GetASTLoc(sm, toAttack);
         std::vector<LExpr> pointerAddends;
         std::vector<LExpr> valueAddends;
         std::vector<LExpr> triggers;

--- a/tools/lavaTool/include/MallocOffByOneArgHandler.h
+++ b/tools/lavaTool/include/MallocOffByOneArgHandler.h
@@ -29,7 +29,7 @@ struct MallocOffByOneArgHandler : public LavaMatchHandler {
         LExpr addend = LDecimal(0);
         const Expr *size_arg = callExpr->getArg(callExpr->getNumArgs() - 1);
 	if (size_arg) {
-        	LavaASTLoc ast_loc = GetASTLoc(sm, size_arg);
+        	ASTLoc ast_loc = GetASTLoc(sm, size_arg);
 		Mod.Change(size_arg);
 		if (LavaAction == LavaQueries)  {
 		    addend = LavaAtpQuery(ast_loc,

--- a/tools/lavaTool/include/MemoryAccessHandler.h
+++ b/tools/lavaTool/include/MemoryAccessHandler.h
@@ -38,7 +38,7 @@ struct MemoryAccessHandler : public LavaMatchHandler {
         }
 
         const SourceManager &sm = *Result.SourceManager;
-        LavaASTLoc ast_loc = GetASTLoc(sm, toAttack);
+        ASTLoc ast_loc = GetASTLoc(sm, toAttack);
         //debug(INJECT) << "PointerAtpHandler @ " << ast_loc << "\n";
 
         const Expr *rhs = nullptr;

--- a/tools/lavaTool/include/PriQueryPointHandler.h
+++ b/tools/lavaTool/include/PriQueryPointHandler.h
@@ -84,7 +84,7 @@ struct PriQueryPointHandler : public LavaMatchHandler {
     // for dua x, offset o, generates:
     // lava_set(slot, *(const unsigned int *)(((const unsigned char *)x)+o)
     // Each lval gets an if clause containing one siphon
-    std::string SiphonsForLocation(LavaASTLoc ast_loc) {
+    std::string SiphonsForLocation(ASTLoc ast_loc) {
         std::stringstream result_ss;
         // We iterate over variables (lvals) that LAVA identified as "siphons" (data sources)
         for (const LvalBytes &lval_bytes : map_get_default(siphons_at, ast_loc)) {
@@ -111,7 +111,7 @@ struct PriQueryPointHandler : public LavaMatchHandler {
         return result;
     }
 
-    std::string AttackRetBuffer(LavaASTLoc ast_loc) {
+    std::string AttackRetBuffer(ASTLoc ast_loc) {
         std::stringstream result_ss;
         auto key = std::make_pair(ast_loc, AttackPoint::QUERY_POINT);
         for (const Bug *bug : map_get_default(bugs_with_atp_at, key)) {
@@ -165,7 +165,7 @@ struct PriQueryPointHandler : public LavaMatchHandler {
             debug(PRI) << "PriQueryPointHandler handle: ok to instrument " << fnname.second << "\n";
         }
 
-        LavaASTLoc ast_loc = GetASTLoc(sm, toSiphon);
+        ASTLoc ast_loc = GetASTLoc(sm, toSiphon);
         debug(PRI) << "Have a query point @ " << ast_loc << "!\n";
 
         std::string before;

--- a/tools/lavaTool/include/ReadDisclosureHandler.h
+++ b/tools/lavaTool/include/ReadDisclosureHandler.h
@@ -61,7 +61,7 @@ struct ReadDisclosureHandler : public LavaMatchHandler {
             const Expr *arg = dyn_cast<Expr>(*it);
             if (arg) {
                 if (arg->IgnoreImpCasts()->isLValue() && arg->getType()->isIntegerType()) {
-                    LavaASTLoc ast_loc = GetASTLoc(sm, arg);
+                    ASTLoc ast_loc = GetASTLoc(sm, arg);
                     Mod.Change(arg);
                     if (LavaAction == LavaQueries)  {
                         addend = LavaAtpQuery(GetASTLoc(sm, arg),

--- a/tools/lavaTool/include/lavaTool.h
+++ b/tools/lavaTool/include/lavaTool.h
@@ -106,7 +106,7 @@ struct LvalBytes {
 
 
 // Map of bugs with siphon of a given  lval name at a given loc.
-std::map<LavaASTLoc, vector_set<LvalBytes>> siphons_at;
+std::map<ASTLoc, vector_set<LvalBytes>> siphons_at;
 std::map<LvalBytes, uint32_t> data_slots;
 
 std::string LavaPath;
@@ -121,7 +121,7 @@ static std::set<std::string> main_files;
 static std::map<std::string, uint32_t> StringIDs;
 
 // Map of bugs with attack points at a given loc.
-std::map<std::pair<LavaASTLoc, AttackPoint::Type>, std::vector<const Bug *>>
+std::map<std::pair<ASTLoc, AttackPoint::Type>, std::vector<const Bug *>>
     bugs_with_atp_at;
 
 static cl::OptionCategory

--- a/tools/lavaTool/src/CMakeLists.txt
+++ b/tools/lavaTool/src/CMakeLists.txt
@@ -74,13 +74,14 @@ set_target_properties(lavaFnTool PROPERTIES LINK_FLAGS "-flto -fuse-ld=gold")
 add_executable(lavaInitTool lavaInitTool.cpp)
 target_compile_features(lavaInitTool PRIVATE cxx_std_17)
 target_include_directories(lavaInitTool PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../lavaODB/generated
     ${CMAKE_CURRENT_SOURCE_DIR}/../../lavaODB/include
     ${CMAKE_CURRENT_SOURCE_DIR}/../../include
     ${CMAKE_CURRENT_SOURCE_DIR}/../include
     ${LLVM_INCLUDE_DIRS}
     ${CLANG_INCLUDE_DIRS}
 )
-target_link_libraries(lavaInitTool PRIVATE ${LLVM_CLANG_LINK_LIBRARIES})
+target_link_libraries(lavaInitTool PRIVATE ${LLVM_CLANG_LINK_LIBRARIES} lava-odb_x64)
 set_target_properties(lavaInitTool PROPERTIES LINK_FLAGS "-flto -fuse-ld=gold")
 
 # Add dependencies

--- a/tools/lavaTool/src/lavaTool.cpp
+++ b/tools/lavaTool/src/lavaTool.cpp
@@ -110,7 +110,7 @@ int main(int argc, const char **argv) {
                 [&](uint32_t bug_id) { return db->load<Bug>(bug_id); });
 
         for (const Bug *bug : bugs) {
-            LavaASTLoc atp_loc = bug->atp->loc;
+            ASTLoc atp_loc = bug->atp->loc;
             auto key = std::make_pair(atp_loc, bug->atp->type);
             bugs_with_atp_at[key].push_back(bug);
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've documented or updated the documentation of every function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
This PR completes the following tasks:
1. Utilize Protobuf to generate some of the C++/Python database classes. Use this to confirm the table names and fields match to protobuf to avoid database drift.
a) For C++ there is a function called `__enforce_proto`, this confirms the fields match what is on protobuf and on the struct. It also confirms the name of the Struct and Protobuf match, e. g. it is called Loc and Loc.
b) For Python a test case was added to confirm it matches with protobuf too.

2. Other minor fixes, such as:
a. changing the argument to just be 'x86_64', not 'panda-system-x86_64'
b. Updating the Hypercall to be multi-arch, prep for ARM 
c. We use the new SQL Alchemy version of Composite, not the hack used.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Ideally, have some tests and/or screenshots that can replicate results -->

Since I am only changing for the database is built, the same CI/CD should pass.
...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
